### PR TITLE
Added pagination feature

### DIFF
--- a/gh
+++ b/gh
@@ -32,6 +32,8 @@ Requires a .netrc file for credentials.
 
   -i --include-headers
     Prints received headers and content.
+  -p --paginate
+    Pulls ALL pages returned from the request.
   -s --stats
     Displays current rate-limit statistics.
   -h --help
@@ -70,6 +72,7 @@ action="";
 url=""
 payload=""
 
+paginate=false
 curl_header_flag=""
 fetch_stats=false
 
@@ -83,6 +86,10 @@ for arg in "$@"; do
 
     --version )
       version
+      ;;
+
+    --paginate | -p )
+      paginate=true
       ;;
 
     --include-headers | -i )
@@ -117,6 +124,12 @@ if ${fetch_stats} ; then
 
   action="get"
   url="/rate_limit"
+fi
+
+# Pagination consumes headers.
+if ${paginate}; then
+  [[ -z "${curl_header_flag}" ]] \
+    || die "Pagination consumes headers. Invalid flag combination."
 fi
 
 
@@ -154,9 +167,66 @@ url=$(sed 's_.*github.com/_/_' <<< "${url}")
 #
 # Do the thing
 #
-curl --silent ${curl_header_flag} \
-  --request "${action}" \
-  --header "Authorization: token ${token}" \
-  --header "Content-Type: application/json" \
-  --data "@${payload}" \
-  --url "$(urlencode "https://api.github.com${url}")"
+if ${paginate}; then
+  rm /tmp/gh.*.json &> /dev/null \
+    || true
+
+  curl --silent --include \
+    --request "${action}" \
+    --header "Authorization: token ${token}" \
+    --header "Content-Type: application/json" \
+    --data "@${payload}" \
+    --url "$(urlencode "https://api.github.com${url}?per_page=100")" \
+    | tee >( \
+      header=$(sed -e '1,\_^\r_!d')
+      cat - > /dev/null
+
+      lastPage="$(
+        <<< "${header}" \
+          sed -e '\_^Link:_!d' \
+            | tr '<' $'\n' \
+            | sed -e '\_last_!d' \
+                  -e 's_.*page=__g' \
+                  -e 's_>.*__g'
+      )"
+      [ -n "${lastPage}" ] || lastPage=1
+        
+
+      pidList=""
+      for page in $(seq 2 "${lastPage}"); do
+        > "/tmp/gh.${page}.json" \
+          curl --silent \
+            --request "${action}" \
+            --header "Authorization: token ${token}" \
+            --header "Content-Type: application/json" \
+            --data "@${payload}" \
+            --url "$(urlencode "https://api.github.com${url}?per_page=100&page=${page}")" &
+
+        pidList="${pidList} $!"
+      done
+
+      wait ${pidList}
+
+    ) \
+      | sed -e '1,\_^\r_d' > "/tmp/gh.1.json"
+
+
+    fileList="$(
+      find '/tmp' -name 'gh.*.json' 2>/dev/null \
+        | sort \
+        | paste -s -d' ' \
+        || true
+    )"
+
+    jq -s '.[]' ${fileList}
+
+    rm /tmp/gh.*.json &> /dev/null \
+      || true
+else
+  curl --silent ${curl_header_flag} \
+    --request "${action}" \
+    --header "Authorization: token ${token}" \
+    --header "Content-Type: application/json" \
+    --data "@${payload}" \
+    --url "$(urlencode "https://api.github.com${url}")"
+fi

--- a/gh
+++ b/gh
@@ -30,10 +30,10 @@ Requires a .netrc file for credentials.
     The json payload used when performing a POST or DELETE <action>.
     Should not be provided with any other <action>.
 
-  -i --include-headers
-    Prints received headers and content.
   -p --paginate
     Pulls ALL pages returned from the request.
+  -i --include-headers
+    Prints received headers and content.
   -s --stats
     Displays current rate-limit statistics.
   -h --help
@@ -167,10 +167,11 @@ url=$(sed 's_.*github.com/_/_' <<< "${url}")
 #
 # Do the thing
 #
-if ${paginate}; then
-  rm /tmp/gh.*.json &> /dev/null \
-    || true
 
+cleanup() { find '/tmp' -name 'gh.*.json' -exec rm {} \; 2>/dev/null || true; }
+trap cleanup EXIT
+
+if ${paginate}; then
   curl --silent --include \
     --request "${action}" \
     --header "Authorization: token ${token}" \
@@ -219,9 +220,6 @@ if ${paginate}; then
     )"
 
     jq -s '.[]' ${fileList}
-
-    rm /tmp/gh.*.json &> /dev/null \
-      || true
 else
   curl --silent ${curl_header_flag} \
     --request "${action}" \


### PR DESCRIPTION
Adds the ability to return ALL results from a request, if the user uses the `--paginate` flag.


While the first request is made, its headers are analyzed for pagination headers while the request is printed to stdout. If the headers are found, the last paginated page is extraced and multiple queries in parallel are started, with the results being written to disk.

Once all jobs have completed, the original request is closed (yes, all of this happens within the original request's context and potentially keeps the socket open), and the reu

#### Dev Notes

This is all done within the context of the original request, potentially keeping the socket open on the client side. This is probably a bad thing, but ItWorks™. 

In bash, it's not possible to set variables within a subshell or grouping, and have the change persist outside of the shell (aside for using a 'set' flag, but would prefer not to). To get around this, the requests are all written to a known location in disk, with a page index. Once all requests have completed and the subshell is closed, the json files are found, and merged together using 'jq'.

Line 180 likely breaks some use cases (aka multiple `?` and now possibly show up in the URL). 

The `if` statement can likely be refactored out if a pagination value of 1 is always assumed.